### PR TITLE
Fix reporting arm state [end_effector pose] 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ find_package(arm_api2_msgs REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(rclpy REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 # include headers
 include_directories(include)
@@ -34,7 +36,7 @@ PUBLIC
 # TODO: Build moveit2_iface
 target_compile_features(moveit2_iface PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 ament_target_dependencies(
-  moveit2_iface moveit_ros moveit_ros_planning_interface moveit_visual_tools rclcpp arm_api2_msgs moveit_servo
+  moveit2_iface moveit_ros moveit_ros_planning_interface moveit_visual_tools rclcpp arm_api2_msgs moveit_servo sensor_msgs geometry_msgs
 )
 
 # Install launch directory

--- a/config/kinova/kinova_sim.yaml
+++ b/config/kinova/kinova_sim.yaml
@@ -21,6 +21,9 @@ topic:
     cmd_delta_pose: 
       name: arm/cmd/deta_pose
       queue: 1  
+    joint_states:
+      name: joint_states
+      queue: 1
   pub:
     display_trajectory:
       name: arm/display_path

--- a/include/arm_api2/moveit2_iface.hpp
+++ b/include/arm_api2/moveit2_iface.hpp
@@ -71,6 +71,7 @@
 //* msgs
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
 #include "arm_api2_msgs/msg/cartesian_waypoints.hpp"
 
 //* srvs
@@ -135,6 +136,7 @@ class m2Iface: public rclcpp::Node
         
         /* subs */
         rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr        pose_cmd_sub_;
+        rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr           joint_state_sub_;
         rclcpp::Subscription<arm_api2_msgs::msg::CartesianWaypoints>::SharedPtr ctraj_cmd_sub_; 
 
         /* pubs */
@@ -146,6 +148,7 @@ class m2Iface: public rclcpp::Node
         /* callbacks */
         void pose_cmd_cb(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
         void cart_poses_cb(const arm_api2_msgs::msg::CartesianWaypoints::SharedPtr msg); 
+        void joint_state_cb(const sensor_msgs::msg::JointState::SharedPtr msg);
         void change_state_cb(const std::shared_ptr<arm_api2_msgs::srv::ChangeState::Request> req, 
                              const std::shared_ptr<arm_api2_msgs::srv::ChangeState::Response> res); 
         bool run(); 
@@ -206,8 +209,10 @@ class m2Iface: public rclcpp::Node
         geometry_msgs::msg::PoseStamped m_currPoseCmd; 
         geometry_msgs::msg::PoseStamped m_pubCurrPoseCmd; 
         geometry_msgs::msg::PoseStamped m_oldPoseCmd; 
-        geometry_msgs::msg::PoseStamped m_currPoseState; 
+        geometry_msgs::msg::PoseStamped m_currPoseState;
+        sensor_msgs::msg::JointState    m_currJointState;  
         std::vector<geometry_msgs::msg::Pose> m_cartesianWaypoints; 
+        
 
         moveit::planning_interface::MoveGroupInterfacePtr m_moveGroupPtr; 
         moveit::core::RobotStatePtr m_robotStatePtr;  

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend>moveit_servo</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <depend>moveit_visual_tools</depend>
   <depend>arm_api2_msgs</depend>
   <depend>moveit_servo</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
EXPLANATION: Upon testing we realized end_effector pose has been reported wrongly
FIX: 
- Added reading of current joint states to update robot state
- Added getting robot pose on different way (similar to how I did it in MoveIt!) 
RESULT: 
- Correctly reported end-effector pose for both ways of robot commanding (topic/rviz2) 
